### PR TITLE
ci: Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+        pages: write
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4.2.2
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3.0.0
+        
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+        pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,4 +2,7 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://jackplowman.github.io',
+  base: 'repo-overseer',
+})


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to set up a deployment workflow for GitHub Pages and configure the site settings for the Astro project. The most important changes include adding a GitHub Actions workflow for deploying to GitHub Pages and updating the Astro configuration file with the site URL and base path.

Deployment workflow setup:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R36): Added a new GitHub Actions workflow to deploy the site to GitHub Pages on push to the main branch. This includes steps for checking out the repository, building the site, and deploying it.

Astro configuration updates:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL5-R8): Updated the configuration file to include the site URL and base path for the Astro project.

Fixes #31