### PR TITLE
ci: Run Validator before Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Python 3.13
-        uses: actions/setup-python@v2.3.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.13
       - name: Install Poetry
@@ -31,8 +31,8 @@ jobs:
       - name: Run Validator
         run: poetry run python3 -m validator
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
       - name: Upload Validator Results
         uses: actions/upload-artifact@v4.5.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,32 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  run-validator:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4.2.2
+        with:
+          repository: JackPlowman/repo_standards_validator
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v2.3.0
+        with:
+          python-version: 3.13
+      - name: Install dependencies
+        run: poetry install
+      - name: Run Validator
+        run: poetry run python3 -m validator
+      - name: Upload Validator Results
+        uses: actions/upload-artifact@v4.5.0
+        with:
+          name: validator-results
+          path: repositories.json
+
+  build-site:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -17,11 +42,19 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Download Validator Results
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: validator-results
+          path: src/data
       - name: Install, build, and upload your site
         uses: withastro/action@v3.0.0
 
   deploy:
-    needs: build
+    needs: build-site
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@v2.3.0
         with:
           python-version: 3.13
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Install dependencies
         run: poetry install
       - name: Run Validator
@@ -39,6 +41,7 @@ jobs:
     permissions:
       id-token: write
       pages: write
+    needs: run-validator
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,10 @@ jobs:
         run: poetry install
       - name: Run Validator
         run: poetry run python3 -m validator
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+
       - name: Upload Validator Results
         uses: actions/upload-artifact@v4.5.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Validator
         run: poetry run python3 -m validator
         env:
-          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
       - name: Upload Validator Results


### PR DESCRIPTION
# Pull Request

## Description


This pull request includes significant changes to the `.github/workflows/deploy.yml` file to introduce a new job for running a repository standards validator and modifying the existing build and deploy jobs to accommodate this new step. The most important changes include the addition of the `run-validator` job, updates to the `build-site` job to depend on the validator, and changes to the `deploy` job dependencies.

Changes to workflow jobs:

* Added a new `run-validator` job to run a repository standards validator. This job includes steps to checkout the repository, set up Python, install dependencies, run the validator, and upload the results.

Modifications to existing jobs:

* Updated the `build-site` job to depend on the `run-validator` job and added steps to download the validator results.
* Changed the `deploy` job to depend on the `build-site` job instead of the `build` job.

Fixes #36 
