### PR TITLE
chore: Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    commit-message:
+      prefix: "deps(github-actions)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new configuration file `.github/dependabot.yml` to automate dependency updates for GitHub Actions. The configuration specifies the update schedule, commit message format, and target branch for the updates.

Automated dependency updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R21): Added configuration to automate updates for GitHub Actions dependencies, scheduled to run weekly on Saturdays at 01:00 London time. The updates will target the `main` branch and include both patch and minor updates.

Fixes #19 
