### PR TITLE
chore: Add Dependabot Configuration for Updating NPM Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,21 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "."
+    commit-message:
+      prefix: "deps(typescript)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      typescript:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant update to the `.github/dependabot.yml` file to add a new configuration for managing TypeScript dependencies. The most important changes include specifying a new package ecosystem for npm, defining the commit message prefix, scheduling the updates, and grouping the updates by type.

Key changes:

* Added a new package ecosystem for `npm` with the directory set to `"."`.
* Defined the commit message prefix as `"deps(typescript)"`.
* Scheduled the updates to occur weekly on Saturdays at 01:00 in the Europe/London timezone.
* Set the target branch for the updates to `"main"`.
* Created a group for TypeScript updates, specifying patterns and update types (patch and minor).

Fixes #43 
