### PR TITLE
ci: Add Markdown Link Checker

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -91,3 +91,21 @@ jobs:
         run: just prettier-check
       - name: Run ESLint
         run: just lint
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to add a new job for checking Markdown links and to configure the link checking tool. The most important changes include adding a new job in the GitHub Actions workflow and configuring the `.linkspector.yml` file.

Configuration changes:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R7): Added configuration for directories to check, excluded files, and status codes considered as alive.

Workflow changes:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R94-R111): Added a new job named `check-markdown-links` to the GitHub Actions workflow to check Markdown links using the `UmbrellaDocs/action-linkspector` action.

Fixes #14
