### PR TITLE
ci: Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -109,3 +109,17 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check

--- a/Justfile
+++ b/Justfile
@@ -21,3 +21,15 @@ prettier-check:
 # Format code with Prettier
 prettier-format:
     npx prettier . --check --write
+
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+# Format the Just code
+format:
+    just --fmt --unstable
+
+# Check for Just format issues
+format-check:
+    just --fmt --check --unstable


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow to check the format of Justfiles and adds corresponding commands to the Justfile. The most important changes include the addition of a new job in the GitHub Actions workflow and the inclusion of format and format-check commands in the Justfile.

Workflow enhancements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R112-R125): Added a new job `check-justfile-format` to check the format of Justfiles using the `just format-check` command.

Justfile updates:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR24-R35): Added `format` and `format-check` commands to format and check the format of Justfiles, respectively.

Fixes #15 
