### PR TITLE
chore: Add Python Test Dependency Updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,18 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "pip"
+    directory: "tests"
+    commit-message:
+      prefix: "deps(python-tests)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python-tests:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an important addition to the `.github/dependabot.yml` file. The change introduces a new configuration for managing Python dependencies in the `tests` directory using Dependabot.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R40-R54): Added a new configuration for the `pip` package ecosystem to manage dependencies in the `tests` directory. The updates are scheduled weekly on Saturdays at 01:00 London time, with commit messages prefixed by "deps(python-tests)".

Fixes #60
