### PR TITLE
ci: Run UI Tests after Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,4 +96,4 @@ jobs:
         working-directory: tests
         run: poetry install
       - name: Run UI Tests
-        run: just ui-tests
+        run: just tests::ui-tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,5 +95,7 @@ jobs:
       - name: Install dependencies
         working-directory: tests
         run: poetry install
+      - name: Install Playwright Dependencies
+        run: just tests::playwright-install
       - name: Run UI Tests
         run: just tests::ui-tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,8 +93,7 @@ jobs:
       - name: Install Poetry
         run: pipx install poetry==2.0.0
       - name: Install dependencies
-        working-directory: tests
-        run: poetry install
+        run: just tests::install
       - name: Install Playwright Dependencies
         run: just tests::playwright-install
       - name: Run UI Tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,3 +74,26 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
+
+  ui-tests:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.13
+      - name: Install Poetry
+        run: pipx install poetry==2.0.0
+      - name: Install dependencies
+        working-directory: tests
+        run: poetry install
+      - name: Run UI Tests
+        run: just ui-tests

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -1,3 +1,41 @@
+# ------------------------------------------------------------------------------
+# Common Commands
+# ------------------------------------------------------------------------------
+
+# Install python dependencies
+install:
+    poetry install
+
+# Install playwright dependencies
+playwright-install:
+    poetry run playwright install
+
 # Run ui playwright tests
 ui-tests:
     poetry run pytest ui
+
+# ------------------------------------------------------------------------------
+# Ruff - Python Linting and Formating
+# Set up ruff red-knot when it's ready
+# ------------------------------------------------------------------------------
+
+# Fix all Ruff issues
+ruff-fix:
+    just tests::ruff-format-fix
+    just tests::ruff-lint-fix
+
+# Check for Ruff issues
+ruff-lint:
+    poetry run ruff check .
+
+# Fix Ruff lint issues
+ruff-lint-fix:
+    poetry run ruff check . --fix
+
+# Check for Ruff format issues
+ruff-format:
+    poetry run ruff format --check .
+
+# Fix Ruff format issues
+ruff-format-fix:
+    poetry run ruff format .


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job for running UI tests and adds several commands for managing dependencies and linting in the `tests/tests.just` file.

### New Job for UI Tests:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R77-R100): Added a new job `ui-tests` that runs after the deployment job. It sets up the environment, installs dependencies, and runs UI tests using Playwright.

### Commands for Dependency Management and Linting:

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R1-R41): Added commands for installing Python and Playwright dependencies, running UI tests, and managing Ruff linting and formatting issues.

Fixes #61 
