### PR TITLE
ci: Add Link Tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/deploy-pages@v4.0.5
 
   ui-tests:
+    name: UI Tests
     runs-on: ubuntu-latest
     needs: deploy
     steps:
@@ -98,3 +99,21 @@ jobs:
         run: just tests::playwright-install
       - name: Run UI Tests
         run: just tests::ui-tests
+
+  link-tests:
+    name: Link Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Link Tests
+        uses: JustinBeckwith/linkinator-action@v1.11.0
+        with:
+          paths: https://jackplowman.github.io/repo-overseer
+          recurse: true
+          timeout: 1000
+          markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces new job configurations to the GitHub Actions workflow file `.github/workflows/deploy.yml`. The changes primarily add a new job for link tests and provide a name for the existing UI tests job.

New job configurations:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R102-R119): Added a `link-tests` job to run link tests using the `JustinBeckwith/linkinator-action@v1.11.0` action. This job runs after the deploy job and includes steps for checking out the repository and running the link tests.

Naming updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R79): Added a name (`UI Tests`) to the existing `ui-tests` job for better clarity.

Fixes #65 
