### PR TITLE
ci: Add Zizmor Scanning

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: just tests::install
       - name: Run zizmor 🌈
-        run: poetry -C tests run zizmor --format sarif . > results.sarif
+        run: poetry -C tests run zizmor --format sarif .. > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -118,3 +118,34 @@ jobs:
         uses: extractions/setup-just@v2
       - name: Check Justfile Format
         run: just format-check
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.13
+      - name: Install Poetry
+        run: pipx install poetry==2.0.0
+      - name: Install dependencies
+        run: just tests::install
+      - name: Run zizmor 🌈
+        run: poetry -C tests run zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.28.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout your repository using git
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           repository: JackPlowman/repo_standards_validator
@@ -46,7 +46,7 @@ jobs:
       pages: write
     needs: run-validator
     steps:
-      - name: Checkout your repository using git
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-      - name: Checkout your repository using git
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to improve clarity and add a new job for running `zizmor`. The most important changes include renaming the checkout steps and adding a new job to check GitHub Actions with `zizmor`.

Improvements to job names:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L19-R19): Renamed the checkout steps to "Checkout Repository" for better clarity. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L59-R59)
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L17-R17): Renamed the checkout steps to "Checkout Repository" for better clarity. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L17-R17) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L49-R49) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L83-R83) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L108-R108)

Addition of new job:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R121-R151): Added a new job `run-zizmor` to check GitHub Actions with `zizmor`, including steps to set up the repository, Python, Poetry, and run `zizmor`.

Fixes #24
