### PR TITLE
chore: Add Ruff Configuration

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -13,3 +13,44 @@ package-mode = false
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["ALL"]
+
+ignore = [
+  "COM812",  # Ignore due to conflict with Ruff formatter
+  "ISC001",  # Ignore due to conflict with Ruff formatter
+  "PLR2004", # Ignore magic value
+  "D104",    # Ignore missing docstring in public package
+  "D100",    # Ignore missing docstring in public module
+  "SIM112",  # Ignore Lowercase environment variables (used for GitHub actions)
+]
+
+fixable = ["ALL"]
+unfixable = []
+
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+]
+
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -1,8 +1,10 @@
 from playwright.sync_api import Page, expect
+
 from .utils.constants import DASHBOARD_URL
 
 
-def test_has_title(page: Page) -> None:
+def test_dashboard_has_title(page: Page) -> None:
+    """Check that the dashboard has the correct title."""
     # Act
     page.goto(DASHBOARD_URL)
     # Assert


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces configuration for the Ruff linter and includes a minor update to a test function name and its docstring. The most important changes are as follows:

### Ruff Linter Configuration:
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dR16-R56): Added Ruff linter configuration, specifying target version, selected checks, ignored checks, fixable and unfixable categories, excluded directories, and a regex for dummy variables.

### Test Function Update:
* [`tests/ui/test_dashboard.py`](diffhunk://#diff-0f5c761cdc6013814735e5a86f696efa96ebec90d540a4517d2deb396fdefbf7R2-R7): Renamed the test function `test_has_title` to `test_dashboard_has_title` and added a docstring to describe its purpose.
