### PR TITLE
build: Link Repository Name to GitHub Page

### DIFF
--- a/dashboard/src/components/columns.tsx
+++ b/dashboard/src/components/columns.tsx
@@ -3,9 +3,11 @@ import { Badge } from "@/components/ui/badge"
 import type { ColumnDef } from "@tanstack/react-table"
 import { GitPullRequest, Shield, ShieldAlert } from "lucide-react"
 
+
 type Repository = {
   name: string
   full_name: string
+  repository_link: string
   secret_scanning_push_protection: boolean
   secret_scanning: boolean
   dependabot_security_updates: boolean
@@ -15,9 +17,18 @@ export const columns: ColumnDef<Repository>[] = [
   {
     accessorKey: "name",
     header: "Repository",
-    cell: ({ row }) => (
-      <div className="font-medium">{row.getValue("name")}</div>
-    ),
+    cell: ({ row }) => {
+      return (
+        <a
+          href={ row.original.repository_link}
+          className="text-primary hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {row.original.name}
+        </a>
+      )
+    },
   },
   {
     accessorKey: "secret_scanning_push_protection",

--- a/dashboard/src/components/columns.tsx
+++ b/dashboard/src/components/columns.tsx
@@ -3,7 +3,6 @@ import { Badge } from "@/components/ui/badge"
 import type { ColumnDef } from "@tanstack/react-table"
 import { GitPullRequest, Shield, ShieldAlert } from "lucide-react"
 
-
 type Repository = {
   name: string
   full_name: string
@@ -20,7 +19,7 @@ export const columns: ColumnDef<Repository>[] = [
     cell: ({ row }) => {
       return (
         <a
-          href={ row.original.repository_link}
+          href={row.original.repository_link}
           className="text-primary hover:underline"
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `dashboard/src/components/columns.tsx` file to enhance the display of repository information in the dashboard. The most important changes include adding a new property to the `Repository` type and updating the column definition to create clickable links for repository names.

Enhancements to repository display:

* [`dashboard/src/components/columns.tsx`](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R9): Added a new property `repository_link` to the `Repository` type to store the URL of the repository.
* [`dashboard/src/components/columns.tsx`](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3L18-R30): Updated the `name` column definition to render the repository name as a clickable link that opens in a new tab.

Fixes #104
