### PR TITLE
chore: Update Page Title

### DIFF
--- a/dashboard/src/layouts/Layout.astro
+++ b/dashboard/src/layouts/Layout.astro
@@ -9,7 +9,8 @@
       href={`${import.meta.env.BASE_URL}/favicon.svg`}
     />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro Basics</title>
+    <title>Repository Security Overview</title>
+    <link rel="sitemap" href="/sitemap-index.xml" />
   </head>
   <body>
     <slot />

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -9,7 +9,7 @@ def test_has_title(page: Page) -> None:
     # Act
     page.goto(DASHBOARD_URL)
     # Assert
-    expect(page).to_have_title("Astro Basics")
+    expect(page).to_have_title("Repository Security Overview")
 
 
 def test_sitemap_index() -> None:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `dashboard` project to reflect a new title and add a sitemap link. The changes also include updates to the corresponding test cases to ensure they align with the new title.

Changes to the layout and metadata:

* [`dashboard/src/layouts/Layout.astro`](diffhunk://#diff-5f757a7d2e52d2bc5226cc6d64fbcf9b17fa90e57b96c550f5c2ec426c3eaa76L12-R13): Updated the page title from "Astro Basics" to "Repository Security Overview" and added a link to the sitemap (`/sitemap-index.xml`).

Updates to test cases:

* [`tests/ui/test_dashboard.py`](diffhunk://#diff-0f5c761cdc6013814735e5a86f696efa96ebec90d540a4517d2deb396fdefbf7L12-R12): Modified the test `test_has_title` to expect the new title "Repository Security Overview".

Fixes #93

