### PR TITLE
chore: Fix Sitemap Index Link

### DIFF
--- a/dashboard/src/layouts/Layout.astro
+++ b/dashboard/src/layouts/Layout.astro
@@ -10,7 +10,10 @@
     />
     <meta name="generator" content={Astro.generator} />
     <title>Repository Security Overview</title>
-    <link rel="sitemap" href={`${import.meta.env.BASE_URL}/sitemap-index.xml`} />
+    <link
+      rel="sitemap"
+      href={`${import.meta.env.BASE_URL}/sitemap-index.xml`}
+    />
   </head>
   <body>
     <slot />

--- a/dashboard/src/layouts/Layout.astro
+++ b/dashboard/src/layouts/Layout.astro
@@ -10,7 +10,7 @@
     />
     <meta name="generator" content={Astro.generator} />
     <title>Repository Security Overview</title>
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" href={`${import.meta.env.BASE_URL}/sitemap-index.xml`} />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `dashboard/src/layouts/Layout.astro` file to dynamically set the sitemap URL based on the environment's base URL.

* [`dashboard/src/layouts/Layout.astro`](diffhunk://#diff-5f757a7d2e52d2bc5226cc6d64fbcf9b17fa90e57b96c550f5c2ec426c3eaa76L13-R16): Updated the `href` attribute of the sitemap link to use `import.meta.env.BASE_URL` for dynamic URL generation.
