### PR TITLE
build: Set Table Selector Width

### DIFF
--- a/dashboard/src/components/RepositoryTable.tsx
+++ b/dashboard/src/components/RepositoryTable.tsx
@@ -5,15 +5,21 @@ import { repositories } from "@/data/repositories.json"
 
 export default function RepositoryTable() {
   return (
-    <Tabs defaultValue="details" className="w-full">
-      <TabsList>
-        <TabsTrigger value="details">Details</TabsTrigger>
-        <TabsTrigger value="security">Security</TabsTrigger>
+    <Tabs defaultValue="details" className="w-full" data-oid="ta6u1k3">
+      <TabsList data-oid="m63_zzl">
+        <TabsTrigger value="details" data-oid="ovi6q_5">
+          Details
+        </TabsTrigger>
+        <TabsTrigger value="security" data-oid="n87_ht1">
+          Security
+        </TabsTrigger>
       </TabsList>
-      <TabsContent value="details">
-        <DataTable columns={columns} data={repositories} />
+      <TabsContent value="details" data-oid="8x-4q-k">
+        <DataTable columns={columns} data={repositories} data-oid="xaq_j_f" />
       </TabsContent>
-      <TabsContent value="security">Put content here</TabsContent>
+      <TabsContent value="security" data-oid="dp.d_bj">
+        Put content here
+      </TabsContent>
     </Tabs>
   )
 }

--- a/dashboard/src/components/columns.tsx
+++ b/dashboard/src/components/columns.tsx
@@ -20,9 +20,10 @@ export const columns: ColumnDef<Repository>[] = [
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          data-oid="mzy24.j"
         >
           Repository
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+          <ArrowUpDown className="ml-2 h-4 w-4" data-oid="vrmdjdu" />
         </Button>
       )
     },
@@ -33,6 +34,7 @@ export const columns: ColumnDef<Repository>[] = [
           className="text-primary hover:underline"
           target="_blank"
           rel="noopener noreferrer"
+          data-oid="rbrxftz"
         >
           {row.original.name}
         </a>
@@ -45,14 +47,16 @@ export const columns: ColumnDef<Repository>[] = [
       <Button
         variant="ghost"
         onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        data-oid="vc45.rx"
       >
-        <div className="flex items-center gap-2">
-          <ShieldAlert className="h-4 w-4" />
-          <span>Push Protection</span>
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+        <div className="flex items-center gap-2" data-oid="ilfoxue">
+          <ShieldAlert className="h-4 w-4" data-oid="c4d1:45" />
+          <span data-oid="99k9lox">Push Protection</span>
+          <ArrowUpDown className="ml-2 h-4 w-4" data-oid="xftjt86" />
         </div>
       </Button>
     ),
+
     cell: ({ row }) => (
       <Badge
         variant={
@@ -60,6 +64,7 @@ export const columns: ColumnDef<Repository>[] = [
             ? "success"
             : "destructive"
         }
+        data-oid="72pk1fs"
       >
         {row.getValue("secret_scanning_push_protection")
           ? "Enabled"
@@ -73,17 +78,20 @@ export const columns: ColumnDef<Repository>[] = [
       <Button
         variant="ghost"
         onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        data-oid="w5h7r72"
       >
-        <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4" />
-          <span>Secret Scanning</span>
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+        <div className="flex items-center gap-2" data-oid="m1bkq7i">
+          <Shield className="h-4 w-4" data-oid="cq2:avt" />
+          <span data-oid="x2a4q_.">Secret Scanning</span>
+          <ArrowUpDown className="ml-2 h-4 w-4" data-oid="_ryk0st" />
         </div>
       </Button>
     ),
+
     cell: ({ row }) => (
       <Badge
         variant={row.getValue("secret_scanning") ? "success" : "destructive"}
+        data-oid="oobta2d"
       >
         {row.getValue("secret_scanning") ? "Enabled" : "Disabled"}
       </Badge>
@@ -95,14 +103,16 @@ export const columns: ColumnDef<Repository>[] = [
       <Button
         variant="ghost"
         onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        data-oid="793p:2d"
       >
-        <div className="flex items-center gap-2">
-          <GitPullRequest className="h-4 w-4" />
-          <span>Dependabot</span>
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+        <div className="flex items-center gap-2" data-oid="_b1m5g2">
+          <GitPullRequest className="h-4 w-4" data-oid="qr3ftrv" />
+          <span data-oid="9e1-f2v">Dependabot</span>
+          <ArrowUpDown className="ml-2 h-4 w-4" data-oid="muz0bsd" />
         </div>
       </Button>
     ),
+
     cell: ({ row }) => (
       <Badge
         variant={
@@ -110,6 +120,7 @@ export const columns: ColumnDef<Repository>[] = [
             ? "success"
             : "destructive"
         }
+        data-oid="79lcad:"
       >
         {row.getValue("dependabot_security_updates") ? "Enabled" : "Disabled"}
       </Badge>

--- a/dashboard/src/components/data-table.tsx
+++ b/dashboard/src/components/data-table.tsx
@@ -50,13 +50,13 @@ export function DataTable<TData, TValue>({
   })
 
   return (
-    <div>
-      <Table>
-        <TableHeader>
+    <div data-oid="qa4mgng">
+      <Table data-oid="0q22gk7">
+        <TableHeader data-oid=":ufh-hf">
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
+            <TableRow key={headerGroup.id} data-oid="_bb6spf">
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead key={header.id} data-oid="vszox0:">
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -68,32 +68,40 @@ export function DataTable<TData, TValue>({
             </TableRow>
           ))}
         </TableHeader>
-        <TableBody>
+        <TableBody data-oid="c4ufubr">
           {table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
+              <TableRow key={row.id} data-oid="alp5:um">
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  <TableCell key={cell.id} data-oid="2f_zqbu">
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}
               </TableRow>
             ))
           ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
+            <TableRow data-oid="el7n3k7">
+              <TableCell
+                colSpan={columns.length}
+                className="h-24 text-center"
+                data-oid="0ycj-ei"
+              >
                 No repositories found.
               </TableCell>
             </TableRow>
           )}
         </TableBody>
       </Table>
-      <div className="flex items-center justify-end space-x-2 py-4">
+      <div
+        className="flex items-center justify-end space-x-2 py-4"
+        data-oid=".oi0s4t"
+      >
         <Button
           variant="outline"
           size="sm"
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
+          data-oid="d:l-xkm"
         >
           Previous
         </Button>
@@ -102,6 +110,7 @@ export function DataTable<TData, TValue>({
           size="sm"
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}
+          data-oid="nlvwwn4"
         >
           Next
         </Button>

--- a/dashboard/src/components/ui/badge.tsx
+++ b/dashboard/src/components/ui/badge.tsx
@@ -31,7 +31,11 @@ export interface BadgeProps
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <div
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+      data-oid="3rgw0d1"
+    />
   )
 }
 

--- a/dashboard/src/components/ui/button.tsx
+++ b/dashboard/src/components/ui/button.tsx
@@ -50,6 +50,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
+        data-oid="3zlbhv0"
       />
     )
   }

--- a/dashboard/src/components/ui/table.tsx
+++ b/dashboard/src/components/ui/table.tsx
@@ -8,11 +8,12 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-auto" data-oid="56efpa5">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}
       {...props}
+      data-oid="fmkwpje"
     />
   </div>
 ))
@@ -22,7 +23,12 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn("[&_tr]:border-b", className)}
+    {...props}
+    data-oid="4658l6j"
+  />
 ))
 TableHeader.displayName = "TableHeader"
 
@@ -34,6 +40,7 @@ const TableBody = React.forwardRef<
     ref={ref}
     className={cn("[&_tr:last-child]:border-0", className)}
     {...props}
+    data-oid="ydy7:6q"
   />
 ))
 TableBody.displayName = "TableBody"
@@ -49,6 +56,7 @@ const TableFooter = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="b3q:9_8"
   />
 ))
 TableFooter.displayName = "TableFooter"
@@ -64,6 +72,7 @@ const TableRow = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="lj-1bzo"
   />
 ))
 TableRow.displayName = "TableRow"
@@ -80,6 +89,7 @@ const TableHead = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="kgvwqdp"
   />
 ))
 TableHead.displayName = "TableHead"
@@ -96,6 +106,7 @@ const TableCell = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="9ba42gt"
   />
 ))
 TableCell.displayName = "TableCell"
@@ -108,6 +119,7 @@ const TableCaption = React.forwardRef<
     ref={ref}
     className={cn("mt-4 text-sm text-muted-foreground", className)}
     {...props}
+    data-oid="0e8p8iv"
   />
 ))
 TableCaption.displayName = "TableCaption"

--- a/dashboard/src/components/ui/tabs.tsx
+++ b/dashboard/src/components/ui/tabs.tsx
@@ -16,6 +16,7 @@ const TabsList = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="8h0a4au"
   />
 ))
 TabsList.displayName = TabsPrimitive.List.displayName
@@ -28,9 +29,11 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
+      className,
+      "w-1/2"
     )}
     {...props}
+    data-oid="94:w0i2"
   />
 ))
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
@@ -46,6 +49,7 @@ const TabsContent = React.forwardRef<
       className
     )}
     {...props}
+    data-oid="m1-_pw3"
   />
 ))
 TabsContent.displayName = TabsPrimitive.Content.displayName


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes across multiple files to add `data-oid` attributes for tracking purposes. The most important changes include modifications to the `RepositoryTable`, `columns`, `data-table`, `badge`, `button`, `table`, and `tabs` components.

### Tracking Attributes Addition:

* **RepositoryTable Component**:
  - Added `data-oid` attributes to `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` elements.

* **Columns Component**:
  - Added `data-oid` attributes to various elements within the `columns` definition, including `Button`, `ArrowUpDown`, `a` tags, `ShieldAlert`, `Badge`, and `GitPullRequest`. [[1]](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R23-R26) [[2]](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R37) [[3]](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R50-R67) [[4]](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R81-R94) [[5]](diffhunk://#diff-911097980600deaf4c658f70d24ffc5cde6d9e393aec77f360241c34507341a3R106-R123)

* **DataTable Component**:
  - Added `data-oid` attributes to `div`, `Table`, `TableHeader`, `TableBody`, `TableRow`, `TableCell`, and `Button` elements. [[1]](diffhunk://#diff-32cb1b40149d093fbc8c5965c88324d99733fbfc5d9218d2e9cc6154f52b28feL53-R59) [[2]](diffhunk://#diff-32cb1b40149d093fbc8c5965c88324d99733fbfc5d9218d2e9cc6154f52b28feL71-R104) [[3]](diffhunk://#diff-32cb1b40149d093fbc8c5965c88324d99733fbfc5d9218d2e9cc6154f52b28feR113)

* **UI Components**:
  - Added `data-oid` attributes to `Badge`, `Button`, `Table`, `TableHeader`, `TableBody`, `TableFooter`, `TableRow`, `TableHead`, `TableCell`, `TableCaption`, `TabsList`, `TabsTrigger`, and `TabsContent` elements. [[1]](diffhunk://#diff-a62122d2e5a0e5912cb0549bf886bd3592378c70bdc5fddaf29aa7187b819a66L34-R38) [[2]](diffhunk://#diff-44fbe7c08457c6cde9caa4074b1475a6513c4e783e80f4297692d116833ebd92R53) [[3]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbL11-R16) [[4]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbL25-R31) [[5]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR43) [[6]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR59) [[7]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR75) [[8]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR92) [[9]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR109) [[10]](diffhunk://#diff-6f2d8d841e1454d6662c701cbb7424c402621fd54a4c87d710b7f0b2aec178fbR122) [[11]](diffhunk://#diff-6364ba3cf424cafbc6a1ed20e58abc407ebb2c95710d7ad0b447d4a5bf2e5684R19) [[12]](diffhunk://#diff-6364ba3cf424cafbc6a1ed20e58abc407ebb2c95710d7ad0b447d4a5bf2e5684L31-R36) [[13]](diffhunk://#diff-6364ba3cf424cafbc6a1ed20e58abc407ebb2c95710d7ad0b447d4a5bf2e5684R52)
