### PR TITLE
build: Update Button Colours

### DIFF
--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -66,12 +66,16 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       </Button>
     ),
     cell: ({ row }) => (
-      <Badge variant="default" className={
-        row.getValue("open_pull_requests") > 3
-          ? "bg-amber-600"
-          : "bg-green-600"
-      }
-      >{row.getValue("open_issues")}</Badge>
+      <Badge
+        variant="default"
+        className={
+          row.getValue("open_pull_requests") > 3
+            ? "bg-amber-600"
+            : "bg-green-600"
+        }
+      >
+        {row.getValue("open_issues")}
+      </Badge>
     ),
   },
 ]

--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -3,18 +3,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { Repository } from "@/lib/types"
 import type { ColumnDef } from "@tanstack/react-table"
-import {
-  ArrowUpDown,
-  CheckIcon,
-  CircleDot,
-  CrossIcon,
-  GitPullRequest,
-} from "lucide-react"
-
-export const GreenCheckIcon = () => (
-  <CheckIcon className="h-4 w-4 text-green-500" />
-)
-export const RedCrossIcon = () => <CrossIcon className="h-4 w-4 text-red-500" />
+import { ArrowUpDown, CircleDot, GitPullRequest } from "lucide-react"
 
 export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
   {
@@ -52,7 +41,17 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       </Button>
     ),
     cell: ({ row }) => (
-      <Badge variant="default">{row.getValue("open_pull_requests")}</Badge>
+      <Badge
+        variant="default"
+        className={
+          row.getValue("open_pull_requests") > 3
+            ? "bg-amber-600"
+            : "bg-green-600"
+        }
+      >
+        {/*  */}
+        {row.getValue("open_pull_requests")}
+      </Badge>
     ),
   },
   {
@@ -67,7 +66,12 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       </Button>
     ),
     cell: ({ row }) => (
-      <Badge variant="default">{row.getValue("open_issues")}</Badge>
+      <Badge variant="default" className={
+        row.getValue("open_pull_requests") > 3
+          ? "bg-amber-600"
+          : "bg-green-600"
+      }
+      >{row.getValue("open_issues")}</Badge>
     ),
   },
 ]

--- a/dashboard/src/components/RepositoryKeyFilesColumns.tsx
+++ b/dashboard/src/components/RepositoryKeyFilesColumns.tsx
@@ -3,7 +3,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { Repository } from "@/lib/types"
 import type { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown, CheckIcon, ShieldAlert,X } from "lucide-react"
+import { ArrowUpDown, CheckIcon, ShieldAlert, X } from "lucide-react"
 
 export const GreenCheckIcon = () => (
   <CheckIcon className="h-6 w-6 text-green-500" />

--- a/dashboard/src/components/RepositoryKeyFilesColumns.tsx
+++ b/dashboard/src/components/RepositoryKeyFilesColumns.tsx
@@ -3,12 +3,12 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { Repository } from "@/lib/types"
 import type { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown, CheckIcon, CrossIcon, ShieldAlert } from "lucide-react"
+import { ArrowUpDown, CheckIcon, ShieldAlert,X } from "lucide-react"
 
 export const GreenCheckIcon = () => (
-  <CheckIcon className="h-4 w-4 text-green-500" />
+  <CheckIcon className="h-6 w-6 text-green-500" />
 )
-export const RedCrossIcon = () => <CrossIcon className="h-4 w-4 text-red-500" />
+export const RedCrossIcon = () => <X className="h-6 w-6 text-red-500" />
 
 export const RepositoryKeyFileColumns: ColumnDef<Repository>[] = [
   {

--- a/dashboard/src/components/RepositorySecurityColumns.tsx
+++ b/dashboard/src/components/RepositorySecurityColumns.tsx
@@ -49,10 +49,10 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-        variant={
+        variant="default"
+        className={
           row.getValue("secret_scanning_push_protection")
-            ? "success"
-            : "destructive"
+            ? "bg-green-400" : "bg-red-400"
         }
       >
         {row.getValue("secret_scanning_push_protection")
@@ -75,7 +75,11 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-        variant={row.getValue("secret_scanning") ? "success" : "destructive"}
+      variant="default"
+      className={
+        row.getValue("secret_scanning")
+          ? "bg-green-400" : "bg-red-400"
+      }
       >
         {row.getValue("secret_scanning") ? "Enabled" : "Disabled"}
       </Badge>
@@ -95,11 +99,10 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-        variant={
-          row.getValue("dependabot_security_updates")
-            ? "success"
-            : "destructive"
-        }
+      className={
+        row.getValue("dependabot_security_updates")
+          ? "bg-green-400" : "bg-red-400"
+      }
       >
         {row.getValue("dependabot_security_updates") ? "Enabled" : "Disabled"}
       </Badge>
@@ -119,11 +122,10 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-        variant={
-          row.getValue("private_vulnerability_disclosures")
-            ? "success"
-            : "destructive"
-        }
+      className={
+        row.getValue("private_vulnerability_disclosures")
+          ? "bg-green-400" : "bg-red-400"
+      }
       >
         {row.getValue("private_vulnerability_disclosures")
           ? "Enabled"
@@ -145,9 +147,11 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-        variant={
-          row.getValue("code_scanning_alerts") === 0 ? "success" : "destructive"
-        }
+      className={
+        row.getValue("code_scanning_alerts") === 0
+          ? "bg-green-400" : "bg-red-400"
+      }
+
       >
         {row.getValue("code_scanning_alerts")}
       </Badge>

--- a/dashboard/src/components/RepositorySecurityColumns.tsx
+++ b/dashboard/src/components/RepositorySecurityColumns.tsx
@@ -52,7 +52,8 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
         variant="default"
         className={
           row.getValue("secret_scanning_push_protection")
-            ? "bg-green-400" : "bg-red-400"
+            ? "bg-green-400"
+            : "bg-red-400"
         }
       >
         {row.getValue("secret_scanning_push_protection")
@@ -75,11 +76,10 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-      variant="default"
-      className={
-        row.getValue("secret_scanning")
-          ? "bg-green-400" : "bg-red-400"
-      }
+        variant="default"
+        className={
+          row.getValue("secret_scanning") ? "bg-green-400" : "bg-red-400"
+        }
       >
         {row.getValue("secret_scanning") ? "Enabled" : "Disabled"}
       </Badge>
@@ -99,10 +99,11 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-      className={
-        row.getValue("dependabot_security_updates")
-          ? "bg-green-400" : "bg-red-400"
-      }
+        className={
+          row.getValue("dependabot_security_updates")
+            ? "bg-green-400"
+            : "bg-red-400"
+        }
       >
         {row.getValue("dependabot_security_updates") ? "Enabled" : "Disabled"}
       </Badge>
@@ -122,10 +123,11 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-      className={
-        row.getValue("private_vulnerability_disclosures")
-          ? "bg-green-400" : "bg-red-400"
-      }
+        className={
+          row.getValue("private_vulnerability_disclosures")
+            ? "bg-green-400"
+            : "bg-red-400"
+        }
       >
         {row.getValue("private_vulnerability_disclosures")
           ? "Enabled"
@@ -147,11 +149,11 @@ export const RepositorySecurityColumns: ColumnDef<Repository>[] = [
 
     cell: ({ row }) => (
       <Badge
-      className={
-        row.getValue("code_scanning_alerts") === 0
-          ? "bg-green-400" : "bg-red-400"
-      }
-
+        className={
+          row.getValue("code_scanning_alerts") === 0
+            ? "bg-green-400"
+            : "bg-red-400"
+        }
       >
         {row.getValue("code_scanning_alerts")}
       </Badge>


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the `dashboard/src/components` files, focusing on improving the visual representation of data in the `Badge` components and updating icon usage. The key changes include modifying the `Badge` component's class names based on conditions and updating the icon sizes and imports.

### Visual Improvements:

* [`dashboard/src/components/RepositoryDetailColumns.tsx`](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eL55-R54): Updated the `Badge` component's class to change the background color based on the number of open pull requests and issues. [[1]](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eL55-R54) [[2]](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eL70-R74)

### Icon Updates:

* [`dashboard/src/components/RepositoryDetailColumns.tsx`](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eL6-R6): Removed unused icons and updated the import statement to include only the necessary icons.
* [`dashboard/src/components/RepositoryKeyFilesColumns.tsx`](diffhunk://#diff-9022d5265d034e4497814de03ff0de7f79d6fed32ca95cc17422a9c255a6af4cL6-R11): Updated the size of the `CheckIcon` and `CrossIcon` and replaced `CrossIcon` with `X` for better clarity.

### Security Column Updates:

* [`dashboard/src/components/RepositorySecurityColumns.tsx`](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L52-R55): Modified the `Badge` component's class names to use specific background colors instead of variant names for various security-related columns. [[1]](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L52-R55) [[2]](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L78-R82) [[3]](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L98-R104) [[4]](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L122-R127) [[5]](diffhunk://#diff-1bbedce9e1f24ae279a33dd5a6fe34679450ab626c98133529544bbf77d6e993L148-R154)
