### PR TITLE
ci: Run deployment every hour

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 permissions:
   contents: read

--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -69,7 +69,7 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       <Badge
         variant="default"
         className={
-          row.getValue("open_pull_requests") > 3
+          row.getValue("open_issues") > 3
             ? "bg-amber-600"
             : "bg-green-600"
         }

--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -69,9 +69,7 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       <Badge
         variant="default"
         className={
-          row.getValue("open_issues") > 3
-            ? "bg-amber-600"
-            : "bg-green-600"
+          row.getValue("open_issues") > 3 ? "bg-amber-600" : "bg-green-600"
         }
       >
         {row.getValue("open_issues")}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the GitHub Actions workflow configuration to add a scheduled deployment.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R7-R8): Added a cron schedule to trigger the workflow every hour.

Fixes #42 