### PR TITLE
build: Link Issues Count to GitHub Tab

### DIFF
--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -78,14 +78,14 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
         target="_blank"
         rel="noopener noreferrer"
       >
-      <Badge
-        variant="default"
-        className={
-          row.getValue("open_issues") > 3 ? "bg-amber-600" : "bg-green-600"
-        }
-      >
-        {row.getValue("open_issues")}
-      </Badge>
+        <Badge
+          variant="default"
+          className={
+            row.getValue("open_issues") > 3 ? "bg-amber-600" : "bg-green-600"
+          }
+        >
+          {row.getValue("open_issues")}
+        </Badge>
       </a>
     ),
   },

--- a/dashboard/src/components/RepositoryDetailColumns.tsx
+++ b/dashboard/src/components/RepositoryDetailColumns.tsx
@@ -72,6 +72,12 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       </Button>
     ),
     cell: ({ row }) => (
+      <a
+        href={`${row.original.repository_link}/issues`}
+        className="hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
       <Badge
         variant="default"
         className={
@@ -80,6 +86,7 @@ export const RepositoryDetailColumns: ColumnDef<Repository>[] = [
       >
         {row.getValue("open_issues")}
       </Badge>
+      </a>
     ),
   },
 ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `RepositoryDetailColumns` component in the `dashboard/src/components/RepositoryDetailColumns.tsx` file. The main update is the addition of a hyperlink to the repository issues page within the `cell` rendering logic.

Enhancements to the `RepositoryDetailColumns` component:

* Added an anchor tag around the `Badge` component to link to the repository's issues page. This makes the number of open issues clickable, directing users to the issues page in a new tab. (`dashboard/src/components/RepositoryDetailColumns.tsx`) [[1]](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eR75-R80) [[2]](diffhunk://#diff-e1cf8cee5106901b7bc15f9193d142819cca9797beae05943113409a644d251eR89)

Fixes #174 
