### PR TITLE
chore: Rename UI Tests

### DIFF
--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -424,31 +424,31 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.9.4"
+version = "0.9.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706"},
-    {file = "ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf"},
-    {file = "ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0"},
-    {file = "ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402"},
-    {file = "ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e"},
-    {file = "ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41"},
-    {file = "ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7"},
+    {file = "ruff-0.9.6-py3-none-linux_armv6l.whl", hash = "sha256:2f218f356dd2d995839f1941322ff021c72a492c470f0b26a34f844c29cdf5ba"},
+    {file = "ruff-0.9.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b908ff4df65dad7b251c9968a2e4560836d8f5487c2f0cc238321ed951ea0504"},
+    {file = "ruff-0.9.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b109c0ad2ececf42e75fa99dc4043ff72a357436bb171900714a9ea581ddef83"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1de4367cca3dac99bcbd15c161404e849bb0bfd543664db39232648dc00112dc"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac3ee4d7c2c92ddfdaedf0bf31b2b176fa7aa8950efc454628d477394d35638b"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dc1edd1775270e6aa2386119aea692039781429f0be1e0949ea5884e011aa8e"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4a091729086dffa4bd070aa5dab7e39cc6b9d62eb2bef8f3d91172d30d599666"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1bbc6808bf7b15796cef0815e1dfb796fbd383e7dbd4334709642649625e7c5"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:589d1d9f25b5754ff230dce914a174a7c951a85a4e9270613a2b74231fdac2f5"},
+    {file = "ruff-0.9.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc61dd5131742e21103fbbdcad683a8813be0e3c204472d520d9a5021ca8b217"},
+    {file = "ruff-0.9.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5e2d9126161d0357e5c8f30b0bd6168d2c3872372f14481136d13de9937f79b6"},
+    {file = "ruff-0.9.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:68660eab1a8e65babb5229a1f97b46e3120923757a68b5413d8561f8a85d4897"},
+    {file = "ruff-0.9.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4cae6c4cc7b9b4017c71114115db0445b00a16de3bcde0946273e8392856f08"},
+    {file = "ruff-0.9.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19f505b643228b417c1111a2a536424ddde0db4ef9023b9e04a46ed8a1cb4656"},
+    {file = "ruff-0.9.6-py3-none-win32.whl", hash = "sha256:194d8402bceef1b31164909540a597e0d913c0e4952015a5b40e28c146121b5d"},
+    {file = "ruff-0.9.6-py3-none-win_amd64.whl", hash = "sha256:03482d5c09d90d4ee3f40d97578423698ad895c87314c4de39ed2af945633caa"},
+    {file = "ruff-0.9.6-py3-none-win_arm64.whl", hash = "sha256:0e2bb706a2be7ddfea4a4af918562fdc1bcb16df255e5fa595bbd800ce322a5a"},
+    {file = "ruff-0.9.6.tar.gz", hash = "sha256:81761592f72b620ec8fa1068a6fd00e98a5ebee342a3642efd84454f3031dca9"},
 ]
 
 [[package]]
@@ -495,28 +495,28 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "zizmor"
-version = "1.3.0"
+version = "1.3.1"
 description = "Static analysis for GitHub Actions"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "zizmor-1.3.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a30f7da86caee6c4dc12ac8b9946e824c8717d4b5f939a371c21ae827e972841"},
-    {file = "zizmor-1.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a6f4c02457fa53e780f5542db45e58db7293c7ce8439cedd17ceaa5a0481618b"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20bba9366147f4594743090102df07ac919de59872af3c4b5016414cf759e454"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:081c386c9f14ae831aa45c4c3f75ab1848e24f6cae6ecd30e42fcc2c6fe550f7"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7be14dd3981f7f29b0ced4dfdede80a27631b5fdbca2d74aea325234a9892f1d"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f88a3e617b3c25d381a701329ee8900d090fc0f42281fbe0c56b1ae2b40e34de"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9392bd39b19886a8c01ae39f230542013efd20a1bb38f6aef7072eb7bff8301b"},
-    {file = "zizmor-1.3.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:8bdcd92b1685d7f0054f89cb9cc659ce7a099b9b6f780b5e9a1325a305541ce4"},
-    {file = "zizmor-1.3.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0c50ec5c2fb95f2e6c48660948d49d535289a96566b9373aa8aa6a9dc0ef17a"},
-    {file = "zizmor-1.3.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:99f93ce552bb4d34e8dc0abf03364633b33f441c690a4df99101f6fee12d1acc"},
-    {file = "zizmor-1.3.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:488fe8ceffb551d3a4a14aef3943a8e7c4f3d9458c0995ee5651a79f2ecac060"},
-    {file = "zizmor-1.3.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0f48a1413955827d89252046fadce1cf100f237d529a63e4354812e3d6d209e"},
-    {file = "zizmor-1.3.0-py3-none-win32.whl", hash = "sha256:5783368fe5c9414a1c3e95c0c2811fba0d970060d609cc88a2cb050a7ba61b3a"},
-    {file = "zizmor-1.3.0-py3-none-win_amd64.whl", hash = "sha256:c5e90804a35b9c951d5afb98c726f984d343f1bc6b03eccad98471633234275a"},
-    {file = "zizmor-1.3.0.tar.gz", hash = "sha256:00c02fca187a7579a3faf26789f791d30ff92fdff2ec26b1ef5fe7443e42db4e"},
+    {file = "zizmor-1.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:21f5df91fc4713d6055479e7b4b98973ba42950d86fa11bd82876f5910ee5834"},
+    {file = "zizmor-1.3.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eca8730421777056f8bfc052c188abef95d91b7eff92154f8277f4f7a0dc1e43"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:adcd62f0e5c438211889cecd07cf7a6ef5801016155ef449adbaa929551cd6f5"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14c335bd4900ee278f8dfe0de012a04eefb3ae1a19976ed561dd03636e0bd989"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3873dae75f2bfa5dfe22f123b480bb61d16b8392922350c9d363b81c36445217"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0a98ddc5a3aa2722db168dc1cbcdee4ada6b7afcf11a2a2c84775d15a82918dc"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a2f92d74c48c47fcf7aa0679bdc23fed437f61cc28553ab3f48f6d3392d9b8b"},
+    {file = "zizmor-1.3.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:96fc7fa4ec82be0f8248258a6f1b5ddbd69f69b567bb5654d801d8b2a08b304c"},
+    {file = "zizmor-1.3.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:447c3637f2533680e4b63a93687aa9618257c429021c447f23c2884dbc10387b"},
+    {file = "zizmor-1.3.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:54d8a7bf479d26cd217ce9105aa5961537d398690a40e4df1111c50abf3420f3"},
+    {file = "zizmor-1.3.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:29d0a0fa44803566688f0b0ce0d5e2bd28cde23b3ce67d0ff3efed672adfb189"},
+    {file = "zizmor-1.3.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:735c2a318f8aac7af5db25eac4face2bef603d7359d1fbe832b3b527c2dac159"},
+    {file = "zizmor-1.3.1-py3-none-win32.whl", hash = "sha256:de975889b15c2f6599f1a3da863a21ada7088d61174aed008d29678008b9d8f9"},
+    {file = "zizmor-1.3.1-py3-none-win_amd64.whl", hash = "sha256:227bcb159f49fffb113e59eda0d712660e48ec40dbf9d4367453441b452d5fda"},
+    {file = "zizmor-1.3.1.tar.gz", hash = "sha256:e3742f9000c9d9474312bc7f2e62249d7970cf45df7a9bb51c6991f0e69ada08"},
 ]
 
 [extras]
@@ -525,4 +525,4 @@ dev = ["ruff", "zizmor"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "5e3eb4079b0aa95adcd59a7b23bb7764b9e83b25ba2a661a02506314b1b86e5a"
+content-hash = "95db2b06eff6c282b8b5673f83b6955aeeb4fa62117519023ebba9697291aa5b"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 dependencies = ["pytest==8.3.4", "pytest-playwright==0.6.2", "requests==2.32.3", "pytest-rerunfailures==15.0.0"]
 
 [project.optional-dependencies]
-dev = ["zizmor==1.3.0", "ruff==0.9.4"]
+dev = ["zizmor==1.3.1", "ruff==0.9.6"]
 
 [tool.poetry]
 package-mode = false

--- a/tests/ui/test_dashboard_details.py
+++ b/tests/ui/test_dashboard_details.py
@@ -1,11 +1,12 @@
 """Test the details tab on the dashboard page."""
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from .utils.constants import DASHBOARD_URL
 
 
-def test_table_sorting__details(page: Page) -> None:
+def test_details_table_sorting__repository(page: Page) -> None:
     """Test that the repository table can be sorted in asc and dsc order."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -30,8 +31,7 @@ def test_table_sorting__details(page: Page) -> None:
     first_repo.wait_for(state="visible")
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
-
-def test_table_pagination__details(page: Page) -> None:
+def test_details_table_pagination(page: Page) -> None:
     """Test that the repository table can be paginated."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -50,4 +50,29 @@ def test_table_pagination__details(page: Page) -> None:
         # Wait for pagination to complete
         page.wait_for_selector("tbody tr")
     # Assert
-    assert count > 1
+    assert count >= 1
+
+
+@pytest.mark.parametrize("column", ["Pull Requests", "Issues"])
+def test_details_column_sorting(column: str, page: Page) -> None:
+    """Test that the details table can be sorted by the specified column."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    # Wait for table to be loaded initially
+    page.wait_for_selector("tbody tr")
+    # Select the details tab
+    page.locator("text=Details").click()
+    # Wait for table to be loaded initially
+    page.wait_for_selector("tbody tr")
+    # Get the column header button
+    sort_button = page.get_by_role("button", name=column)
+    # Act & Assert - First click (ascending)
+    sort_button.click()
+    # Wait for sort to complete and get first cell
+    first_cell = page.locator("tbody tr").first.locator("td").first
+    first_cell.wait_for(state="visible")
+    # Act & Assert - Second click (descending)
+    sort_button.click()
+    # Wait for sort to complete and get first cell
+    first_cell = page.locator("tbody tr").first.locator("td").first
+    first_cell.wait_for(state="visible")

--- a/tests/ui/test_dashboard_details.py
+++ b/tests/ui/test_dashboard_details.py
@@ -31,6 +31,7 @@ def test_details_table_sorting__repository(page: Page) -> None:
     first_repo.wait_for(state="visible")
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
+
 def test_details_table_pagination(page: Page) -> None:
     """Test that the repository table can be paginated."""
     # Arrange

--- a/tests/ui/test_dashboard_key_files.py
+++ b/tests/ui/test_dashboard_key_files.py
@@ -5,7 +5,7 @@ from playwright.sync_api import Page, expect
 from .utils.constants import DASHBOARD_URL
 
 
-def test_table_sorting__key_files(page: Page) -> None:
+def test_key_files_table_sorting__repository(page: Page) -> None:
     """Test that the repository table can be sorted in asc and dsc order."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -31,7 +31,7 @@ def test_table_sorting__key_files(page: Page) -> None:
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
 
-def test_table_pagination__key_files(page: Page) -> None:
+def test_key_files_table_pagination_key_files(page: Page) -> None:
     """Test that the repository table can be paginated."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -50,4 +50,4 @@ def test_table_pagination__key_files(page: Page) -> None:
         # Wait for pagination to complete
         page.wait_for_selector("tbody tr")
     # Assert
-    assert count > 1
+    assert count >= 1

--- a/tests/ui/test_dashboard_security.py
+++ b/tests/ui/test_dashboard_security.py
@@ -5,7 +5,7 @@ from playwright.sync_api import Page, expect
 from .utils.constants import DASHBOARD_URL
 
 
-def test_table_sorting__security(page: Page) -> None:
+def test_security_table_sorting__repository(page: Page) -> None:
     """Test that the repository table can be sorted in asc and dsc order."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -31,7 +31,7 @@ def test_table_sorting__security(page: Page) -> None:
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
 
-def test_table_pagination__security(page: Page) -> None:
+def test_security_table_pagination(page: Page) -> None:
     """Test that the repository table can be paginated."""
     # Arrange
     page.goto(DASHBOARD_URL)
@@ -50,4 +50,4 @@ def test_table_pagination__security(page: Page) -> None:
         # Wait for pagination to complete
         page.wait_for_selector("tbody tr")
     # Assert
-    assert count > 1
+    assert count >= 1


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to dependencies and improvements to the test naming conventions and test cases in the `tests/ui` directory. The most important changes include updating the `dev` dependencies in `tests/pyproject.toml`, renaming test functions for consistency, and adding a new parameterized test case.

Dependency updates:

* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL8-R8): Updated `zizmor` to version 1.3.1 and `ruff` to version 0.9.6.

Test naming and new test case:

* [`tests/ui/test_dashboard_details.py`](diffhunk://#diff-449c8894c23cc82e570b5b695ea79e6bcf07a98992d29de37d92d9a525730d08R3-R9): Renamed test functions for consistency and added a new parameterized test case `test_details_column_sorting` to verify sorting by specified columns. [[1]](diffhunk://#diff-449c8894c23cc82e570b5b695ea79e6bcf07a98992d29de37d92d9a525730d08R3-R9) [[2]](diffhunk://#diff-449c8894c23cc82e570b5b695ea79e6bcf07a98992d29de37d92d9a525730d08L33-R34) [[3]](diffhunk://#diff-449c8894c23cc82e570b5b695ea79e6bcf07a98992d29de37d92d9a525730d08L53-R78)
* [`tests/ui/test_dashboard_key_files.py`](diffhunk://#diff-dda22b85ff93083cd16752c35b23272b58376a932a83adaf32ef5ed1d57ffcaeL8-R8): Renamed test functions for consistency. [[1]](diffhunk://#diff-dda22b85ff93083cd16752c35b23272b58376a932a83adaf32ef5ed1d57ffcaeL8-R8) [[2]](diffhunk://#diff-dda22b85ff93083cd16752c35b23272b58376a932a83adaf32ef5ed1d57ffcaeL34-R34) [[3]](diffhunk://#diff-dda22b85ff93083cd16752c35b23272b58376a932a83adaf32ef5ed1d57ffcaeL53-R53)
* [`tests/ui/test_dashboard_security.py`](diffhunk://#diff-228e9019ceded0e4dacaccce29252eaf2079ef2ea1e4f4c5634aee2afa98057eL8-R8): Renamed test functions for consistency. [[1]](diffhunk://#diff-228e9019ceded0e4dacaccce29252eaf2079ef2ea1e4f4c5634aee2afa98057eL8-R8) [[2]](diffhunk://#diff-228e9019ceded0e4dacaccce29252eaf2079ef2ea1e4f4c5634aee2afa98057eL34-R34) [[3]](diffhunk://#diff-228e9019ceded0e4dacaccce29252eaf2079ef2ea1e4f4c5634aee2afa98057eL53-R53)
