### PR TITLE
test: Add Details Table Link Tests

### DIFF
--- a/tests/tests.just
+++ b/tests/tests.just
@@ -16,7 +16,7 @@ playwright-install:
 
 # Run ui playwright tests (headless)
 ui-tests:
-    poetry run pytest ui $RERUN_CONFIG
+    poetry run pytest ui
 
 # Run ui playwright tests in headed mode
 ui-tests-headed:

--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -13,7 +13,7 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     page.goto(DASHBOARD_URL)
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
-    # Select the details tab
+    # Select the tab
     page.locator(f"text={column}").click()
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")

--- a/tests/ui/test_details.py
+++ b/tests/ui/test_details.py
@@ -26,8 +26,6 @@ def test_values_have_link(column_position: int, link_suffix: str, page: Page) ->
     link = first_cell.locator("a").first
     # Act
     href = link.get_attribute("href")
-    expected_url = (
-        f"https://github.com/JackPlowman/{first_row_repository.text_content()}/{link_suffix}"
-    )
+    expected_url = f"https://github.com/JackPlowman/{first_row_repository.text_content()}/{link_suffix}"
     # Assert
     assert expected_url == href, f"Expected {expected_url} but got {href}"

--- a/tests/ui/test_details.py
+++ b/tests/ui/test_details.py
@@ -1,0 +1,33 @@
+"""Tests for the details table on the page."""
+
+import pytest
+from playwright.sync_api import Page
+
+from .utils.constants import DASHBOARD_URL
+
+
+@pytest.mark.parametrize(
+    ("column_position", "link_suffix"), [(2, "pulls"), (3, "issues")]
+)
+def test_values_have_link(column_position: int, link_suffix: str, page: Page) -> None:
+    """Test that the details table values have the correct link."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    # Wait for table to be loaded initially
+    page.wait_for_selector("tbody tr")
+    # Select the details tab
+    page.locator("text=Details").click()
+    # Wait for table to be loaded initially
+    page.wait_for_selector("tbody tr")
+    # Get the first cell in the column
+    first_row_repo = page.locator("tbody tr td").first
+    first_cell = page.locator(f"tbody tr td:nth-child({column_position})").first
+    # Get the first link in the cell
+    link = first_cell.locator("a").first
+    # Act
+    href = link.get_attribute("href")
+    expected_url = (
+        f"https://github.com/JackPlowman/{first_row_repo.text_content()}/{link_suffix}"
+    )
+    # Assert
+    assert expected_url == href, f"Expected {expected_url} but got {href}"

--- a/tests/ui/test_details.py
+++ b/tests/ui/test_details.py
@@ -20,14 +20,14 @@ def test_values_have_link(column_position: int, link_suffix: str, page: Page) ->
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
     # Get the first cell in the column
-    first_row_repo = page.locator("tbody tr td").first
+    first_row_repository = page.locator("tbody tr td").first
     first_cell = page.locator(f"tbody tr td:nth-child({column_position})").first
     # Get the first link in the cell
     link = first_cell.locator("a").first
     # Act
     href = link.get_attribute("href")
     expected_url = (
-        f"https://github.com/JackPlowman/{first_row_repo.text_content()}/{link_suffix}"
+        f"https://github.com/JackPlowman/{first_row_repository.text_content()}/{link_suffix}"
     )
     # Assert
     assert expected_url == href, f"Expected {expected_url} but got {href}"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the test suite, primarily focusing on the UI tests. The most important changes include modifying the `ui-tests` command, updating a test function in `test_common_table.py`, and adding a new test function in `test_details.py`.

Changes to UI tests:

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L19-R19): Modified the `ui-tests` command to remove the `$RERUN_CONFIG` parameter.

Updates to existing test functions:

* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eL16-R16): Updated the comment in the `test_table_sorting__repository_column` function to reflect a more general tab selection.

New test functions:

* [`tests/ui/test_details.py`](diffhunk://#diff-2c07ec40f1e5f99ed3651fe6b9f3440942612a12f54522e40561ac2ce192eb35R1-R33): Added a new test function `test_values_have_link` to verify that the details table values have the correct link.

Fixes #196 