### PR TITLE
chore: Migrate Poetry to UV 2

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -11,6 +11,6 @@ runs:
         enable-cache: true
     - name: Set up Just
       uses: extractions/setup-just@v2
-    - name: Install Poetry Dependencies
+    - name: Install Python Dependencies
       shell: bash
       run: just tests::install

--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -16,7 +16,7 @@ markdown:
 dependencies:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["**/poetry.lock", "package-lock.json"]
+          - any-glob-to-any-file: ["**/uv.lock", "package-lock.json"]
       - head-branch: ["^dependabot"]
 python:
   - any:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,12 +32,12 @@ jobs:
         uses: actions/setup-python@v5.4.0
         with:
           python-version: 3.13
-      - name: Install Poetry
-        run: pipx install poetry==2.1.1
+      - name: Install UV
+        run: pipx install uv==0.6.2
       - name: Install dependencies
-        run: poetry install
+        run: uv sync
       - name: Run Validator
-        run: poetry run python3 -m validator
+        run: uv run python3 -m validator
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: 3.13
       - name: Install Poetry
-        run: pipx install poetry==2.0.1
+        run: pipx install poetry==2.1.1
       - name: Install dependencies
         run: poetry install
       - name: Run Validator
@@ -42,7 +42,7 @@ jobs:
           INPUT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}
       - name: Upload Validator Results
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: validator-results
           path: repositories.json


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the GitHub Actions and configurations to replace the usage of Poetry with UV for dependency management and validation. The most important changes include updates to the action workflows and configuration files to reflect this transition.

Changes to GitHub Actions and configurations:

* [`.github/actions/setup-python-dependencies/action.yml`](diffhunk://#diff-4cb40b2fa462f005bed001da7016592925ba7d2dfa1011ffdeedf6a8b0f7fedbL14-R14): Changed the step name from "Install Poetry Dependencies" to "Install Python Dependencies."
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L19-R19): Updated the glob pattern for dependency files from `**/poetry.lock` to `**/uv.lock`.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L35-R45): Replaced the installation and usage of Poetry with UV, including steps to install UV, sync dependencies, and run the validator using UV. Also updated the version of the `upload-artifact` action.
