### PR TITLE
chore: Fix Some UI Tests

### DIFF
--- a/tests/tests.just
+++ b/tests/tests.just
@@ -22,6 +22,10 @@ ui-tests:
 ui-tests-headed:
     uv run pytest ui --headed $RERUN_CONFIG
 
+# Run ui playwright tests in headed mode with WIP
+ui-tests-wip:
+    uv run pytest ui --headed -k "wip"
+
 # ------------------------------------------------------------------------------
 # Ruff - Python Linting and Formatting
 # Set up ruff red-knot when it's ready

--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -1,5 +1,7 @@
 """Tests for the common table components."""
 
+from time import sleep
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -11,6 +13,7 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     """Test that the repository column can be sorted in asc and dsc order."""
     # Arrange
     page.goto(DASHBOARD_URL)
+    sleep(1)
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
     # Select the tab
@@ -18,15 +21,14 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
     # Get the repository column header button
-    sort_button = page.get_by_role("button", name="Repository")
     # Act & Assert - First click (ascending)
-    sort_button.click()
+    page.get_by_role("button", name="Repository").click()
     # Wait for sort to complete and get first cell
     first_repo = page.locator("tbody tr").first.locator("td").first
     first_repo.wait_for(state="visible")
-    expect(first_repo).to_contain_text("aws-timing-scripts", timeout=5000)
+    expect(first_repo).to_contain_text("actions-status", timeout=5000)
     # Act & Assert - Second click (descending)
-    sort_button.click()
+    page.get_by_role("button", name="Repository").click()
     # Wait for sort to complete and get first cell
     first_repo = page.locator("tbody tr").first.locator("td").first
     first_repo.wait_for(state="visible")


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the UI tests to add a new test command, import a necessary module, and modify the table sorting test. The most important changes are summarized below:

New test command:

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R25-R28): Added a new command `ui-tests-wip` to run UI Playwright tests in headed mode with the "wip" keyword.

Test improvements:

* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eR3-R4): Imported the `sleep` function from the `time` module to introduce a delay in the table sorting test.
* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eR16-R31): Added a `sleep(1)` call before waiting for the table to be loaded initially in the `test_table_sorting__repository_column` function.
* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eR16-R31): Modified the `test_table_sorting__repository_column` function to use `page.get_by_role("button", name="Repository").click()` directly instead of assigning it to a variable.
* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eR16-R31): Updated the expected text in the first cell after sorting to "actions-status" with a timeout of 5000 milliseconds.
