### PR TITLE
chore: Fix Rest of UI Tests

### DIFF
--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -40,6 +40,7 @@ def test_details_table_pagination(column: str, page: Page) -> None:
     """Test that the table can be paginated."""
     # Arrange
     page.goto(DASHBOARD_URL)
+    sleep(1)
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
     # Select the details tab

--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -34,6 +34,7 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     first_repo.wait_for(state="visible")
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
+
 @pytest.mark.wip
 @pytest.mark.parametrize("column", ["Details", "Security", "Key Files"])
 def test_details_table_pagination(column: str, page: Page) -> None:

--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -34,7 +34,7 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     first_repo.wait_for(state="visible")
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
-
+@pytest.mark.wip
 @pytest.mark.parametrize("column", ["Details", "Security", "Key Files"])
 def test_details_table_pagination(column: str, page: Page) -> None:
     """Test that the table can be paginated."""
@@ -49,11 +49,11 @@ def test_details_table_pagination(column: str, page: Page) -> None:
     page.wait_for_selector("tbody tr")
     # Get the next page button
     count = 0
-    while page.locator("text=Next").first.is_enabled():
+    while page.get_by_role("button", name="Next").get_attribute("disabled") is None:
         next_page_button = page.get_by_role("button", name="Next")
         count += 1
         next_page_button.click()
         # Wait for pagination to complete
         page.wait_for_selector("tbody tr")
     # Assert
-    assert count >= 1
+    assert count == 2

--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -35,7 +35,6 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     expect(first_repo).to_contain_text("useful-commands", timeout=5000)
 
 
-@pytest.mark.wip
 @pytest.mark.parametrize("column", ["Details", "Security", "Key Files"])
 def test_details_table_pagination(column: str, page: Page) -> None:
     """Test that the table can be paginated."""

--- a/tests/ui/test_details.py
+++ b/tests/ui/test_details.py
@@ -1,5 +1,7 @@
 """Tests for the details table on the page."""
 
+from time import sleep
+
 import pytest
 from playwright.sync_api import Page
 
@@ -13,6 +15,7 @@ def test_values_have_link(column_position: int, link_suffix: str, page: Page) ->
     """Test that the details table values have the correct link."""
     # Arrange
     page.goto(DASHBOARD_URL)
+    sleep(1)
     # Wait for table to be loaded initially
     page.wait_for_selector("tbody tr")
     # Select the details tab


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `tests/ui/test_common_table.py` and `tests/ui/test_details.py` files to improve the stability and accuracy of UI tests by adding delays and updating assertions.

Improvements to test stability:

* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eR43): Added a `sleep(1)` call to ensure the table is fully loaded before interacting with it.
* [`tests/ui/test_details.py`](diffhunk://#diff-2c07ec40f1e5f99ed3651fe6b9f3440942612a12f54522e40561ac2ce192eb35R3-R4): Imported the `sleep` function from the `time` module and added a `sleep(1)` call to ensure the table is fully loaded before interacting with it. [[1]](diffhunk://#diff-2c07ec40f1e5f99ed3651fe6b9f3440942612a12f54522e40561ac2ce192eb35R3-R4) [[2]](diffhunk://#diff-2c07ec40f1e5f99ed3651fe6b9f3440942612a12f54522e40561ac2ce192eb35R18)

Enhancements to test accuracy:

* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eL51-R59): Modified the pagination check to use `page.get_by_role("button", name="Next").get_attribute("disabled") is None` instead of `page.locator("text=Next").first.is_enabled()` for better accuracy.
* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eL51-R59): Updated the assertion to check that the pagination count is exactly 2 instead of being greater than or equal to 1.
