### PR TITLE
ci: Don't cancel deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   run-validator:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change removes the `cancel-in-progress` property from the `concurrency` configuration. 

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L15): Removed the `cancel-in-progress: true` line from the `concurrency` configuration.
