### PR TITLE
chore: Update Dependabot Configuration to update UV dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
           - "patch"
           - "minor"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "tests"
     commit-message:
       prefix: "deps(python-tests)"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to change the package ecosystem for dependency updates in the `tests` directory.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L40-R40): Changed the `package-ecosystem` from `"pip"` to `"uv"` for dependency updates in the `tests` directory.