### PR TITLE
ci: Remove Pinact Verify

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -233,17 +233,3 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = ["pytest==8.3.5", "pytest-playwright==0.7.0", "requests==2.32.3",
 dev = ["zizmor==1.6.0", "ruff==0.11.7"]
 
 [tool.uv]
-required-version = "0.6.16"
+required-version = "0.6.17"
 package = false
 
 [tool.ruff]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes two main changes: the removal of the `pinact-verify` job from the GitHub Actions workflow and the update of the `uv` tool's required version in the Python project's `pyproject.toml` file.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L236-L249): Removed the `pinact-verify` job, which included steps for checking out the repository and installing the latest version of `uv`.

### Dependency updates:
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL11-R11): Updated the `uv` tool's `required-version` from `0.6.16` to `0.6.17`.
