### PR TITLE
ci: Validate UV Lock

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -115,6 +115,8 @@ jobs:
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
+      - name: Validate UV Lock
+        run: just tests::uv-lock-check
       - name: Check Python Code Format (Ruff)
         run: just tests::ruff-format-check
         env:

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -33,6 +33,7 @@ ui-tests-wip:
 # Validate uv locked
 uv-lock-check:
     uv lock --check
+
 # ------------------------------------------------------------------------------
 # Ruff - Python Linting and Formatting
 # Set up ruff red-knot when it's ready

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -30,6 +30,9 @@ ui-tests-headed:
 ui-tests-wip:
     uv run pytest ui --headed -k "wip"
 
+# Validate uv locked
+uv-lock-check:
+    uv lock --check
 # ------------------------------------------------------------------------------
 # Ruff - Python Linting and Formatting
 # Set up ruff red-knot when it's ready


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new validation step to ensure the UV lock file is consistent and up-to-date. The changes include adding a validation job to the GitHub Actions workflow and defining a corresponding command in the `just` file.

### Additions to UV lock validation:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R118-R119): Added a new step named "Validate UV Lock" to the code checks workflow, which runs the `uv-lock-check` command to validate the UV lock file.
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R33-R35): Introduced a new `uv-lock-check` command that runs `uv lock --check` to verify the UV lock file.
