### PR TITLE
chore: Fix UI Tests

### DIFF
--- a/tests/ui/test_common_table.py
+++ b/tests/ui/test_common_table.py
@@ -32,7 +32,7 @@ def test_table_sorting__repository_column(column: str, page: Page) -> None:
     # Wait for sort to complete and get first cell
     first_repo = page.locator("tbody tr").first.locator("td").first
     first_repo.wait_for(state="visible")
-    expect(first_repo).to_contain_text("useful-commands", timeout=5000)
+    expect(first_repo).to_contain_text("windows-development-environment", timeout=5000)
 
 
 @pytest.mark.parametrize("column", ["Details", "Security", "Key Files"])


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates a test in the `tests/ui/test_common_table.py` file to reflect a change in the expected content of the first repository column after sorting. 

* [`tests/ui/test_common_table.py`](diffhunk://#diff-34f38616313a0f75a060ce95eca333cdba3d77967f1768d29b8c0c3b61ea322eL35-R35): Modified the `test_table_sorting__repository_column` test to expect "windows-development-environment" instead of "useful-commands" as the text in the first cell of the repository column after sorting.
