### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -25,9 +24,8 @@ updates:
     commit-message:
       prefix: "deps(typescript)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -42,9 +40,8 @@ updates:
     commit-message:
       prefix: "deps(python-tests)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python-tests:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -25,7 +25,7 @@ updates:
       prefix: "deps(typescript)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -41,7 +41,7 @@ updates:
       prefix: "deps(python-tests)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python-tests:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration in `.github/dependabot.yml` to switch from a daily update schedule to a cron-based schedule for various dependency groups. The new schedule runs updates at 7:30 AM UTC daily.

### Changes to Dependabot configuration:

* Updated the schedule for the `github-actions` dependency group to use a cron job (`30 7 * * *`) instead of the previous daily schedule with a fixed time and timezone.
* Updated the schedule for the `typescript` dependency group to use a cron job (`30 7 * * *`) instead of the previous daily schedule with a fixed time and timezone.
* Updated the schedule for the `python-tests` dependency group to use a cron job (`30 7 * * *`) instead of the previous daily schedule with a fixed time and timezone.