### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,21 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "./.github/actions/setup-test-dependencies"
+      - ".github/actions/setup-test-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -26,9 +30,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       typescript:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -42,8 +48,13 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python-tests:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance Dependabot's functionality and improve the clarity of its update rules. The updates include adding time zone specifications, refining directory paths, and introducing new grouping rules for version updates.

### Enhancements to Dependabot configuration:

* Added the `timezone` field with the value `"Europe/London"` to all update schedules, ensuring consistent scheduling across time zones. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R21) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R37) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R51-R60)
* Corrected the directory path for the `setup-test-dependencies` action by removing an unnecessary `./` prefix.

### Grouping improvements:

* Introduced the `applies-to` field with the value `"version-updates"` for the `github-actions`, `typescript`, and `python-tests` groups, clarifying that these rules apply specifically to version updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R21) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R37) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R51-R60)
* Added `exclude-patterns` to the `github-actions` group to exclude updates matching the pattern `"super-linter/*"`.
* Defined `update-types` for the `python-tests` group, specifying that only `patch` and `minor` updates should be considered.