### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -224,14 +224,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Python Dependencies
-        uses: ./.github/actions/setup-test-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv --project tests run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -50,7 +50,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow and build process to replace the setup and execution of Python dependencies with new tools (`uv` and `Just`) and modifies the commands used for running and uploading SARIF files. The most important changes are grouped below by theme.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L227-R236): Replaced the setup of Python dependencies with the installation of the latest version of `uv` and the setup of `Just` using their respective GitHub actions. Updated the command for running `zizmor` to use `just zizmor-check-sarif` and upgraded the `codeql-action/upload-sarif` action to version `v3.28.17`.

### Build process updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL53-R57): Added a new `zizmor-check-sarif` recipe that runs `zizmor` with SARIF output using `uvx`. Updated the existing `zizmor-check` recipe to use `uvx` instead of the previous command.