### PR TITLE
chore: Update Dependabot Configuration for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/*"
+          - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/*"
+          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to refine the exclusion patterns for dependencies.

Configuration updates:

* Adjusted the `exclude-patterns` section to specifically exclude `super-linter/super-linter` instead of all `super-linter/*` and added a new exclusion for `JackPlowman/reusable-workflows/*`.