### PR TITLE
chore: Ignore .venv from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 dashboard
+.venv


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.prettierignore` file to exclude the `.venv` directory from Prettier formatting.
