### PR TITLE
deps(github-actions): Bump super-linter/super-linter from 7.4.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,14 +24,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
-          EDITORCONFIG_FILE_NAME: .editorconfig-checker.json
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false
@@ -80,7 +79,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -110,7 +109,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -151,12 +150,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
 
   run-code-limit:
     name: Run CodeLimit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           INPUT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}
       - name: Upload Validator Results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: validator-results
           path: repositories.json
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download Validator Results
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: validator-results
           path: dashboard/src/data


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use newer versions of their respective actions. The updates include version bumps for linters, SARIF uploaders, CodeQL actions, and artifact management actions, ensuring compatibility and access to the latest features and fixes.

### Workflow Updates in `.github/workflows/code-checks.yml`:

* Updated `super-linter` to version `7.4.0` for improved linting capabilities. Removed the `EDITORCONFIG_FILE_NAME` environment variable.
* Updated `github/codeql-action/upload-sarif` to version `3.28.18` for both ESLint and Ruff analysis results. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R82) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L113-R112)
* Updated `github/codeql-action/init` and `github/codeql-action/analyze` to version `3.28.18` for CodeQL initialization and analysis.

### Workflow Updates in `.github/workflows/deploy.yml`:

* Updated `actions/upload-artifact` to version `4.6.2` for uploading validator results.
* Updated `actions/download-artifact` to version `4.3.0` for downloading validator results.
