### PR TITLE
ci: Update Job to use Validator Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,26 +20,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: "main"
-          repository: JackPlowman/repo_standards_validator
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Python 3.13
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-        with:
-          python-version: 3.13
-      - name: Install UV
-        run: pipx install uv==0.7.4
-      - name: Install dependencies
-        run: uv sync
       - name: Run Validator
-        run: uv run python3 -m validator
-        env:
-          INPUT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          INPUT_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        id: validator
+        uses: JackPlowman/repo_standards_validator@6606c1ff8eca25dd6e361b456ac9ba87b849364f # v1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_OWNER: JackPlowman
       - name: Upload Validator Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the deployment workflow in `.github/workflows/deploy.yml` by replacing multiple individual steps for setting up and running the repository standards validator with a single reusable action. This change reduces complexity and improves maintainability.

### Workflow simplification:

* Replaced the manual setup of Python, dependency installation, and execution of the repository standards validator with the reusable action `JackPlowman/repo_standards_validator@6606c1ff8eca25dd6e361b456ac9ba87b849364f`. This eliminates the need for multiple steps, such as Python setup, `pipx` installation, and manual command execution.
