### PR TITLE
ci: Update Validator Permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         id: validator
         uses: JackPlowman/repo_standards_validator@6606c1ff8eca25dd6e361b456ac9ba87b849364f # v1.0.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           REPOSITORY_OWNER: JackPlowman
       - name: Upload Validator Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the GitHub Actions workflow. The `GITHUB_TOKEN` input for the `repo_standards_validator` action has been replaced with `GH_TOKEN`.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L27-R27): Updated the `repo_standards_validator` action to use `GH_TOKEN` instead of `GITHUB_TOKEN` for authentication.
