### PR TITLE
chore: Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,9 @@ jobs:
         shell: bash
         run: just tests::playwright-install
       - name: Run UI Tests
-        run: just tests::run-ci ${{ matrix.browser }}
+        run: just tests::run-ci "$BROWSER"
+        env:
+          BROWSER: ${{ matrix.browser }}
 
   link-tests:
     name: Link Tests


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/workflows/deploy.yml` file. The change modifies how the browser environment variable is passed to the UI tests in the workflow.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L93-R95): Updated the `Run UI Tests` step to use an explicit `BROWSER` environment variable instead of directly referencing `matrix.browser` in the command.