### PR TITLE
ci: Swap linkinator to linkcheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,9 +105,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
+        uses: filiph/linkcheck@f2c15a0be0d9c83def5df3edcc0f2d6582845f2d # 3.0.0
         with:
-          paths: https://jackplowman.github.io/repo-overseer
-          recurse: true
-          timeout: 1000
-          markdown: false
+          arguments: https://jackplowman.github.io/project-links


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the link-checking tool in the GitHub Actions workflow to a newer and more feature-rich version, along with changes to its configuration.

### Workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L108-R110): Replaced the `linkinator-action` tool with `linkcheck` for running link tests, upgrading from version `1.11.0` to `3.0.0`. Updated the configuration to use the `arguments` parameter instead of `paths`, and removed additional parameters such as `recurse`, `timeout`, and `markdown`.