### PR TITLE
deps(github-actions): Update SuperLinter to v8.0.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
+        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to use a newer version of the Super Linter for code linting.

Workflow dependency update:

* Upgraded the `super-linter` action in `.github/workflows/code-checks.yml` from version `v7.4.0` to `v8.0.0` to ensure the latest linting features and bug fixes are used.