### PR TITLE
ci: Split TypeScript Lint and Format Jobs

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -87,10 +87,33 @@ jobs:
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
-      - name: Run Prettier
-        run: just dashboard::prettier-check
       - name: Run ESLint
         run: just dashboard::lint
+
+  run-typescript-format-checks:
+    name: Run TypeScript Format Checks
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Node.js with Cache
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: "dashboard/package.json"
+          cache: "npm"
+          cache-dependency-path: "dashboard/package-lock.json"
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      - name: Install Dependencies
+        working-directory: dashboard
+        run: npm ci
+      - name: Run Prettier
+        run: just dashboard::prettier-check
 
   run-python-tests-lint-checks:
     name: Run Python Tests Lint Checks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` workflow to improve how formatting checks are run for the dashboard codebase. The main change is to move the Prettier formatting check into a new, dedicated job for TypeScript format checks, which helps organize and clarify the workflow steps.

**Workflow improvements:**

* Removed the Prettier formatting check from the main code checks job to avoid redundancy and streamline the workflow.
* Added a new `run-typescript-format-checks` job that sets up the environment and runs Prettier specifically for TypeScript code, making the workflow more modular and easier to maintain.