### PR TITLE
test: Add more UI Feature Tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dashboard
-.venv
+tests/.venv
+tests/.pytest_cache

--- a/tests/ui/test_details_badges.py
+++ b/tests/ui/test_details_badges.py
@@ -1,0 +1,63 @@
+"""Tests for the Details tab badge color logic and sorting behaviour."""
+
+from time import sleep
+
+import pytest
+from playwright.sync_api import Page
+
+from .utils.constants import DASHBOARD_URL
+
+
+@pytest.mark.skip("TODO: Fix this test")
+def test_details_badge_color_follows_threshold(page: Page) -> None:
+    """Values > 3 should have amber badge; <= 3 should be green."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Details").click()
+    page.wait_for_selector("tbody tr")
+
+    # Act
+    first_row = page.locator("tbody tr").first
+    pr_badge = first_row.locator("td:nth-child(2) span")
+    pr_value = int((pr_badge.text_content() or "0").strip())
+    pr_classes = pr_badge.get_attribute("class") or ""
+    issues_badge = first_row.locator("td:nth-child(3) span")
+    issues_value = int((issues_badge.text_content() or "0").strip())
+    issues_classes = issues_badge.get_attribute("class") or ""
+
+    # Assert
+    if pr_value > 3:
+        assert "bg-amber-600" in pr_classes
+    else:
+        assert "bg-green-600" in pr_classes
+    if issues_value > 3:
+        assert "bg-amber-600" in issues_classes
+    else:
+        assert "bg-green-600" in issues_classes
+
+
+def test_details_sorting_by_repository_changes_order(page: Page) -> None:
+    """Clicking the Repository header should toggle sort order and change top row."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Details").click()
+    page.wait_for_selector("tbody tr")
+
+    def top_repo() -> str:
+        return (
+            page.locator("tbody tr").first.locator("td").first.text_content() or ""
+        ).strip()
+
+    # Act
+    before = top_repo()
+    page.get_by_role("button", name="Repository").click()
+    page.wait_for_selector("tbody tr")
+    mid = top_repo()
+    page.get_by_role("button", name="Repository").click()
+    page.wait_for_selector("tbody tr")
+    after = top_repo()
+
+    # Assert
+    assert before != mid or mid != after or before != after

--- a/tests/ui/test_key_files_icons.py
+++ b/tests/ui/test_key_files_icons.py
@@ -1,0 +1,63 @@
+"""Tests for Key Files tab icons and sorting behavior."""
+
+from time import sleep
+
+import pytest
+from playwright.sync_api import Locator, Page
+
+from .utils.constants import DASHBOARD_URL
+
+
+def _cell_has_green_check(cell_selector: Locator) -> bool:
+    # Badge contains an SVG with class indicating color
+    # For true values icons have 'text-green-500'
+    classes = cell_selector.locator("svg").first.get_attribute("class") or ""
+    return "text-green-500" in classes
+
+
+def _cell_has_red_cross(cell_selector: Locator) -> bool:
+    classes = cell_selector.locator("svg").first.get_attribute("class") or ""
+    return "text-red-500" in classes
+
+
+def test_key_files_icons_match_boolean_values(page: Page) -> None:
+    """Each key-file boolean should render a green check or red cross."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Key Files").click()
+    page.wait_for_selector("tbody tr")
+
+    # Act
+    first_row = page.locator("tbody tr").first
+
+    # Assert: Check several boolean columns by position
+    for idx in range(2, 8):  # columns 2..7 are booleans
+        cell = first_row.locator(f"td:nth-child({idx})")
+        assert _cell_has_green_check(cell) or _cell_has_red_cross(cell)
+
+@pytest.mark.skip("TODO: Fix this test")
+def test_key_files_sorting_changes_order(page: Page) -> None:
+    """Toggling the License header should change ordering."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Key Files").click()
+    page.wait_for_selector("tbody tr")
+
+    def first_repo_name() -> str:
+        return (
+            page.locator("tbody tr").first.locator("td").first.text_content() or ""
+        ).strip()
+
+    # Act
+    before = first_repo_name()
+    page.get_by_test_id("has-license").click()
+    page.wait_for_selector("tbody tr")
+    mid = first_repo_name()
+    page.get_by_test_id("has-license").click()
+    page.wait_for_selector("tbody tr")
+    after = first_repo_name()
+
+    # Assert
+    assert before != mid or mid != after or before != after

--- a/tests/ui/test_security.py
+++ b/tests/ui/test_security.py
@@ -1,0 +1,61 @@
+"""Tests for the Security tab visuals and sorting."""
+
+from time import sleep
+
+from playwright.sync_api import Page
+
+from .utils.constants import DASHBOARD_URL
+
+
+def test_security_code_scanning_badge_color_matches_value(page: Page) -> None:
+    """Cells with code scanning alerts '0' should be green; others red."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Security").click()
+    page.wait_for_selector("tbody tr")
+
+    # Act
+    rows = page.locator("tbody tr").all()[:5]
+
+    # Assert
+    assert rows, "Expected at least one row in security table"
+    for row in rows:
+        last_cell = row.locator("td").last
+        text = (last_cell.text_content() or "").strip()
+        classes = last_cell.locator("*").first.get_attribute("class") or ""
+        if text == "0":
+            assert (
+                "bg-green-400" in classes
+            ), f"Expected green class for 0, got: {classes}"
+        else:
+            assert (
+                "bg-red-400" in classes
+            ), f"Expected red class for non-zero, got: {classes}"
+
+
+def test_security_sorting_changes_order(page: Page) -> None:
+    """Toggling the 'Code Scanning Alerts' header should change row order."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.locator("text=Security").click()
+    page.wait_for_selector("tbody tr")
+
+    def first_repo_name() -> str:
+        return (
+            page.locator("tbody tr").first.locator("td").first.text_content()
+            or ""
+        ).strip()
+
+    # Act
+    before = first_repo_name()
+    page.get_by_role("button", name="Code Scanning Alerts").click()
+    page.wait_for_selector("tbody tr")
+    mid = first_repo_name()
+    page.get_by_role("button", name="Code Scanning Alerts").click()
+    page.wait_for_selector("tbody tr")
+    after = first_repo_name()
+
+    # Assert: At least one of the clicks should change the first item
+    assert before != mid or mid != after or before != after

--- a/tests/ui/test_tabs_and_headers.py
+++ b/tests/ui/test_tabs_and_headers.py
@@ -1,0 +1,66 @@
+"""UI tests covering tab switching and expected headers/links appear."""
+
+from time import sleep
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from .utils.constants import DASHBOARD_URL
+
+
+@pytest.mark.skip("TODO: Fix this test")
+def test_tabs_render_expected_headers(page: Page) -> None:
+    """Verify each tab renders its expected header controls."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.wait_for_selector("tbody tr")
+
+    # Act: Land on Details tab (default)
+    # Assert
+    expect(page.get_by_role("button", name="Repository")).to_be_visible()
+    expect(page.get_by_test_id("pull-requests")).to_be_visible()
+    expect(page.get_by_test_id("issues")).to_be_visible()
+
+    # Act: Switch to Key Files tab
+    page.locator("text=Key Files").click()
+    page.wait_for_selector("tbody tr")
+    # Assert: All expected headers visible
+    for test_id in [
+        "has-license",
+        "has-readme",
+        "has-security-policy",
+        "has-code-of-conduct",
+        "has-contributing",
+        "has-project-technologies",
+    ]:
+        expect(page.get_by_test_id(test_id)).to_be_visible()
+
+    # Act: Switch to Security tab
+    page.locator("text=Security").click()
+    page.wait_for_selector("tbody tr")
+    # Assert: All expected headers visible
+    for test_id in [
+        "secret-scanning-push-protection",
+        "secret-scanning",
+        "dependabot-security-updates",
+        "private-vulnerability-disclosures",
+        "code-scanning-alerts",
+    ]:
+        expect(page.get_by_test_id(test_id)).to_be_visible()
+
+
+def test_repository_cell_has_correct_link_format(page: Page) -> None:
+    """Repository names should link to the GitHub repo (starts with owner's URL)."""
+    # Arrange
+    page.goto(DASHBOARD_URL)
+    sleep(1)
+    page.wait_for_selector("tbody tr")
+
+    # Act
+    first_repo_cell = page.locator("tbody tr").first.locator("td").first
+    first_link = first_repo_cell.locator("a").first
+    href = first_link.get_attribute("href") or ""
+
+    # Assert
+    assert href.startswith("https://github.com/JackPlowman/"), href


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a suite of UI tests using Playwright for the dashboard application, focusing on tab-specific badge/icon rendering, sorting behavior, and header/link visibility. It also updates `.prettierignore` to better target test-related directories. The new tests are organized by dashboard tab (Details, Key Files, Security) and cover both visual correctness and interactive sorting. Several tests are marked with `@pytest.mark.skip` for future fixes.

**UI Test Additions:**

* **Details Tab Tests:**
  - Added tests for badge color logic based on value thresholds and sorting behavior by repository name in the Details tab (`tests/ui/test_details_badges.py`).

* **Key Files Tab Tests:**
  - Added tests to verify green check/red cross icons for boolean columns and sorting by license status in the Key Files tab (`tests/ui/test_key_files_icons.py`).

* **Security Tab Tests:**
  - Added tests to check badge color for code scanning alerts and sorting by alert count in the Security tab (`tests/ui/test_security.py`).

* **Tab Switching & Header/Link Tests:**
  - Added tests for tab switching, header visibility for each tab, and correct repository link formatting (`tests/ui/test_tabs_and_headers.py`).

**Test Environment Configuration:**

* Updated `.prettierignore` to exclude test-specific virtual environment and cache directories (`tests/.venv`, `tests/.pytest_cache`) for cleaner formatting and tooling runs.