### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check-pull-request-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the permissions configuration in the `.github/workflows/pull-request-tasks.yml` workflow. The main change is to scope permissions more narrowly for the `check-pull-request-title` job.

Workflow permissions updates:

* Replaced the global `contents: read` permission with an empty permissions object at the workflow level, and set `pull-requests: read` permission specifically for the `check-pull-request-title` job to follow the principle of least privilege.