### PR TITLE
chore: Update licence to 2026

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT Licence
 
-Copyright (c) 2025 Jack Plowman
+Copyright (c) 2026 Jack Plowman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the copyright year in the `LICENCE` file. The year has been changed from 2025 to 2026 to keep the license information current.